### PR TITLE
[QDB-2225] Fix segfault on query run in Python API

### DIFF
--- a/quasardb_module/CMakeLists.txt
+++ b/quasardb_module/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(quasardb-module)
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CLANG TRUE)

--- a/quasardb_module/blob.hpp
+++ b/quasardb_module/blob.hpp
@@ -61,24 +61,24 @@ public:
         const void * content      = nullptr;
         qdb_size_t content_length = 0;
 
-        QDB_THROW_IF_ERROR(qdb_blob_get(*_handle, _alias.c_str(), &content, &content_length));
+        qdb::qdb_throw_if_error(qdb_blob_get(*_handle, _alias.c_str(), &content, &content_length));
 
         return convert_and_release_content(content, content_length);
     }
 
     void put(const std::string & data, std::chrono::system_clock::time_point expiry = std::chrono::system_clock::time_point{})
     {
-        QDB_THROW_IF_ERROR(qdb_blob_put(*_handle, _alias.c_str(), data.data(), data.size(), expirable_entry::from_time_point(expiry)));
+        qdb::qdb_throw_if_error(qdb_blob_put(*_handle, _alias.c_str(), data.data(), data.size(), expirable_entry::from_time_point(expiry)));
     }
 
     void update(const std::string & data, std::chrono::system_clock::time_point expiry = std::chrono::system_clock::time_point{})
     {
-        QDB_THROW_IF_ERROR(qdb_blob_update(*_handle, _alias.c_str(), data.data(), data.size(), expirable_entry::from_time_point(expiry)));
+        qdb::qdb_throw_if_error(qdb_blob_update(*_handle, _alias.c_str(), data.data(), data.size(), expirable_entry::from_time_point(expiry)));
     }
 
     void remove_if(const std::string & comparand)
     {
-        QDB_THROW_IF_ERROR(qdb_blob_remove_if(*_handle, _alias.c_str(), comparand.data(), comparand.size()));
+        qdb::qdb_throw_if_error(qdb_blob_remove_if(*_handle, _alias.c_str(), comparand.data(), comparand.size()));
     }
 
     pybind11::bytes get_and_remove()
@@ -86,7 +86,7 @@ public:
         const void * content      = nullptr;
         qdb_size_t content_length = 0;
 
-        QDB_THROW_IF_ERROR(qdb_blob_get_and_remove(*_handle, _alias.c_str(), &content, &content_length));
+        qdb::qdb_throw_if_error(qdb_blob_get_and_remove(*_handle, _alias.c_str(), &content, &content_length));
 
         return convert_and_release_content(content, content_length);
     }
@@ -97,7 +97,7 @@ public:
         const void * content      = nullptr;
         qdb_size_t content_length = 0;
 
-        QDB_THROW_IF_ERROR(qdb_blob_get_and_update(
+        qdb::qdb_throw_if_error(qdb_blob_get_and_update(
             *_handle, _alias.c_str(), data.data(), data.size(), expirable_entry::from_time_point(expiry), &content, &content_length));
 
         return convert_and_release_content(content, content_length);
@@ -113,7 +113,7 @@ public:
         qdb_error_t err = qdb_blob_compare_and_swap(*_handle, _alias.c_str(), new_value.data(), new_value.size(), comparand.data(),
             comparand.size(), expirable_entry::from_time_point(expiry), &content, &content_length);
 
-        // we don't want to throw on "unmatching content", so we don't use the QDB_THROW_IF_ERROR macro
+        // we don't want to throw on "unmatching content", so we don't use the qdb::qdb_throw_if_error function
         if (QDB_FAILURE(err)) throw qdb::exception{err};
 
         return convert_and_release_content(content, content_length);

--- a/quasardb_module/cluster.hpp
+++ b/quasardb_module/cluster.hpp
@@ -95,7 +95,7 @@ public:
         const char * content      = nullptr;
         qdb_size_t content_length = 0;
 
-        QDB_THROW_IF_ERROR(qdb_node_config(*_handle, uri.c_str(), &content, &content_length));
+        qdb::qdb_throw_if_error(qdb_node_config(*_handle, uri.c_str(), &content, &content_length));
 
         return convert_to_json_and_release(content);
     }
@@ -105,7 +105,7 @@ public:
         const char * content      = nullptr;
         qdb_size_t content_length = 0;
 
-        QDB_THROW_IF_ERROR(qdb_node_status(*_handle, uri.c_str(), &content, &content_length));
+        qdb::qdb_throw_if_error(qdb_node_status(*_handle, uri.c_str(), &content, &content_length));
 
         return convert_to_json_and_release(content);
     }
@@ -115,7 +115,7 @@ public:
         const char * content      = nullptr;
         qdb_size_t content_length = 0;
 
-        QDB_THROW_IF_ERROR(qdb_node_topology(*_handle, uri.c_str(), &content, &content_length));
+        qdb::qdb_throw_if_error(qdb_node_topology(*_handle, uri.c_str(), &content, &content_length));
 
         return convert_to_json_and_release(content);
     }
@@ -206,22 +206,22 @@ public:
 public:
     void purge_all(std::chrono::milliseconds timeout_ms)
     {
-        QDB_THROW_IF_ERROR(qdb_purge_all(*_handle, static_cast<int>(timeout_ms.count())));
+        qdb::qdb_throw_if_error(qdb_purge_all(*_handle, static_cast<int>(timeout_ms.count())));
     }
 
     void purge_cache(std::chrono::milliseconds timeout_ms)
     {
-        QDB_THROW_IF_ERROR(qdb_purge_cache(*_handle, static_cast<int>(timeout_ms.count())));
+        qdb::qdb_throw_if_error(qdb_purge_cache(*_handle, static_cast<int>(timeout_ms.count())));
     }
 
     void wait_for_stabilization(std::chrono::milliseconds timeout_ms)
     {
-        QDB_THROW_IF_ERROR(qdb_wait_for_stabilization(*_handle, static_cast<int>(timeout_ms.count())));
+        qdb::qdb_throw_if_error(qdb_wait_for_stabilization(*_handle, static_cast<int>(timeout_ms.count())));
     }
 
     void trim_all(std::chrono::milliseconds timeout_ms)
     {
-        QDB_THROW_IF_ERROR(qdb_trim_all(*_handle, static_cast<int>(timeout_ms.count())));
+        qdb::qdb_throw_if_error(qdb_trim_all(*_handle, static_cast<int>(timeout_ms.count())));
     }
 
 private:

--- a/quasardb_module/entry.hpp
+++ b/quasardb_module/entry.hpp
@@ -88,7 +88,7 @@ public:
 
         std::transform(tags.cbegin(), tags.cend(), tag_pointers.begin(), [](const std::string & s) { return s.c_str(); });
 
-        QDB_THROW_IF_ERROR(qdb_attach_tags(*_handle, _alias.c_str(), tag_pointers.data(), tag_pointers.size()));
+        qdb::qdb_throw_if_error(qdb_attach_tags(*_handle, _alias.c_str(), tag_pointers.data(), tag_pointers.size()));
     }
 
     bool detach_tag(const std::string & tag)
@@ -105,7 +105,7 @@ public:
 
         std::transform(tags.cbegin(), tags.cend(), tag_pointers.begin(), [](const std::string & s) { return s.c_str(); });
 
-        QDB_THROW_IF_ERROR(qdb_detach_tags(*_handle, _alias.c_str(), tag_pointers.data(), tag_pointers.size()));
+        qdb::qdb_throw_if_error(qdb_detach_tags(*_handle, _alias.c_str(), tag_pointers.data(), tag_pointers.size()));
     }
 
     bool has_tag(const std::string & tag)
@@ -118,7 +118,7 @@ public:
         const char ** tags = nullptr;
         size_t tag_count   = 0;
 
-        QDB_THROW_IF_ERROR(qdb_get_tags(*_handle, _alias.c_str(), &tags, &tag_count));
+        qdb::qdb_throw_if_error(qdb_get_tags(*_handle, _alias.c_str(), &tags, &tag_count));
 
         return convert_strings_and_release(_handle, tags, tag_count);
     }
@@ -126,14 +126,14 @@ public:
 public:
     void remove()
     {
-        QDB_THROW_IF_ERROR(qdb_remove(*_handle, _alias.c_str()));
+        qdb::qdb_throw_if_error(qdb_remove(*_handle, _alias.c_str()));
     }
 
     qdb::hostname get_location()
     {
         qdb_remote_node_t rn;
 
-        QDB_THROW_IF_ERROR(qdb_get_location(*_handle, _alias.c_str(), &rn));
+        qdb::qdb_throw_if_error(qdb_get_location(*_handle, _alias.c_str(), &rn));
 
         qdb::hostname res{rn.address, rn.port};
 
@@ -146,7 +146,7 @@ public:
     {
         qdb_entry_metadata_t md;
 
-        QDB_THROW_IF_ERROR(qdb_get_metadata(*_handle, _alias.c_str(), &md));
+        qdb::qdb_throw_if_error(qdb_get_metadata(*_handle, _alias.c_str(), &md));
 
         return metadata{md};
     }
@@ -180,12 +180,12 @@ public:
 public:
     void expires_at(const std::chrono::system_clock::time_point & expiry_time)
     {
-        QDB_THROW_IF_ERROR(qdb_expires_at(*_handle, _alias.c_str(), from_time_point(expiry_time)));
+        qdb::qdb_throw_if_error(qdb_expires_at(*_handle, _alias.c_str(), from_time_point(expiry_time)));
     }
 
     void expires_from_now(std::chrono::milliseconds expiry_delta)
     {
-        QDB_THROW_IF_ERROR(qdb_expires_from_now(*_handle, _alias.c_str(), expiry_delta.count()));
+        qdb::qdb_throw_if_error(qdb_expires_from_now(*_handle, _alias.c_str(), expiry_delta.count()));
     }
 
     std::chrono::system_clock::time_point get_expiry_time()

--- a/quasardb_module/handle.hpp
+++ b/quasardb_module/handle.hpp
@@ -59,7 +59,7 @@ public:
 
     void connect(const std::string & uri)
     {
-        QDB_THROW_IF_ERROR(qdb_connect(_handle, uri.c_str()));
+        qdb::qdb_throw_if_error(qdb_connect(_handle, uri.c_str()));
     }
 
     operator qdb_handle_t() const noexcept

--- a/quasardb_module/options.hpp
+++ b/quasardb_module/options.hpp
@@ -47,55 +47,55 @@ public:
 public:
     void set_timeout(std::chrono::milliseconds ms)
     {
-        QDB_THROW_IF_ERROR(qdb_option_set_timeout(*_handle, static_cast<int>(ms.count())));
+        qdb::qdb_throw_if_error(qdb_option_set_timeout(*_handle, static_cast<int>(ms.count())));
     }
 
     std::chrono::milliseconds get_timeout()
     {
         int ms = 0;
 
-        QDB_THROW_IF_ERROR(qdb_option_get_timeout(*_handle, &ms));
+        qdb::qdb_throw_if_error(qdb_option_get_timeout(*_handle, &ms));
 
         return std::chrono::milliseconds{ms};
     }
 
     void set_stabilization_max_wait(std::chrono::milliseconds ms)
     {
-        QDB_THROW_IF_ERROR(qdb_option_set_stabilization_max_wait(*_handle, static_cast<int>(ms.count())));
+        qdb::qdb_throw_if_error(qdb_option_set_stabilization_max_wait(*_handle, static_cast<int>(ms.count())));
     }
 
     std::chrono::milliseconds get_stabilization_max_wait()
     {
         int ms = 0;
 
-        QDB_THROW_IF_ERROR(qdb_option_get_stabilization_max_wait(*_handle, &ms));
+        qdb::qdb_throw_if_error(qdb_option_get_stabilization_max_wait(*_handle, &ms));
 
         return std::chrono::milliseconds{ms};
     }
 
     void set_max_cardinality(qdb_uint_t cardinality)
     {
-        QDB_THROW_IF_ERROR(qdb_option_set_max_cardinality(*_handle, cardinality));
+        qdb::qdb_throw_if_error(qdb_option_set_max_cardinality(*_handle, cardinality));
     }
 
     void set_compression(qdb_compression_t level)
     {
-        QDB_THROW_IF_ERROR(qdb_option_set_compression(*_handle, level));
+        qdb::qdb_throw_if_error(qdb_option_set_compression(*_handle, level));
     }
 
     void set_encryption(qdb_encryption_t algo)
     {
-        QDB_THROW_IF_ERROR(qdb_option_set_encryption(*_handle, algo));
+        qdb::qdb_throw_if_error(qdb_option_set_encryption(*_handle, algo));
     }
 
     void set_cluster_public_key(const std::string & key)
     {
-        QDB_THROW_IF_ERROR(qdb_option_set_cluster_public_key(*_handle, key.c_str()));
+        qdb::qdb_throw_if_error(qdb_option_set_cluster_public_key(*_handle, key.c_str()));
     }
 
     void set_user_credentials(const std::string & user, const std::string & private_key)
     {
-        QDB_THROW_IF_ERROR(qdb_option_set_user_credentials(*_handle, user.c_str(), private_key.c_str()));
+        qdb::qdb_throw_if_error(qdb_option_set_user_credentials(*_handle, user.c_str(), private_key.c_str()));
     }
 
 private:

--- a/quasardb_module/query.cpp
+++ b/quasardb_module/query.cpp
@@ -263,7 +263,7 @@ query::query_result query::run()
 {
     qdb_query_result_t * result = nullptr;
 
-    QDB_THROW_IF_ERROR(qdb_exp_query(*_handle, _query_string.c_str(), &result));
+    qdb::qdb_throw_if_error(qdb_exp_query(*_handle, _query_string.c_str(), &result), [&]() noexcept { qdb_release(*_handle, result); });
 
     query::query_result converted_result{};
     if (nullptr != result)

--- a/quasardb_module/query.cpp
+++ b/quasardb_module/query.cpp
@@ -265,18 +265,19 @@ query::query_result query::run()
 
     QDB_THROW_IF_ERROR(qdb_exp_query(*_handle, _query_string.c_str(), &result));
 
-    query::query_result converted_result;
-
-    converted_result.scanned_rows_count = result->scanned_rows_count;
-    converted_result.tables.reserve(result->tables_count);
-
-    for (size_t t = 0; t < result->tables_count; ++t)
+    query::query_result converted_result{};
+    if (nullptr != result)
     {
-        insert_table_result(converted_result, result->tables[t]);
+        converted_result.scanned_rows_count = result->scanned_rows_count;
+        converted_result.tables.reserve(result->tables_count);
+
+        for (size_t t = 0; t < result->tables_count; ++t)
+        {
+            insert_table_result(converted_result, result->tables[t]);
+        }
+
+        qdb_release(*_handle, result);
     }
-
-    qdb_release(*_handle, result);
-
     return converted_result;
 }
 

--- a/quasardb_module/query.hpp
+++ b/quasardb_module/query.hpp
@@ -67,7 +67,7 @@ public:
         const char ** aliases = nullptr;
         size_t count          = 0;
 
-        QDB_THROW_IF_ERROR(qdb_query_find(*_handle, _query_string.c_str(), &aliases, &count));
+        qdb::qdb_throw_if_error(qdb_query_find(*_handle, _query_string.c_str(), &aliases, &count));
 
         return convert_strings_and_release(_handle, aliases, count);
     }

--- a/quasardb_module/tag.hpp
+++ b/quasardb_module/tag.hpp
@@ -48,7 +48,7 @@ public:
         const char ** aliases = nullptr;
         size_t count          = 0;
 
-        QDB_THROW_IF_ERROR(qdb_get_tagged(*_handle, _alias.c_str(), &aliases, &count));
+        qdb::qdb_throw_if_error(qdb_get_tagged(*_handle, _alias.c_str(), &aliases, &count));
 
         return convert_strings_and_release(_handle, aliases, count);
     }
@@ -57,7 +57,7 @@ public:
     {
         qdb_uint_t count = 0;
 
-        QDB_THROW_IF_ERROR(qdb_get_tagged_count(*_handle, _alias.c_str(), &count));
+        qdb::qdb_throw_if_error(qdb_get_tagged_count(*_handle, _alias.c_str(), &count));
 
         return count;
     }

--- a/quasardb_module/ts.hpp
+++ b/quasardb_module/ts.hpp
@@ -94,13 +94,13 @@ public:
     void create(const std::vector<column_info> & columns, std::chrono::milliseconds shard_size = std::chrono::hours{24})
     {
         const auto c_columns = convert_columns(columns);
-        QDB_THROW_IF_ERROR(qdb_ts_create(*_handle, _alias.c_str(), shard_size.count(), c_columns.data(), c_columns.size()));
+        qdb::qdb_throw_if_error(qdb_ts_create(*_handle, _alias.c_str(), shard_size.count(), c_columns.data(), c_columns.size()));
     }
 
     void insert_columns(const std::vector<column_info> & columns)
     {
         const auto c_columns = convert_columns(columns);
-        QDB_THROW_IF_ERROR(qdb_ts_insert_columns(*_handle, _alias.c_str(), c_columns.data(), c_columns.size()));
+        qdb::qdb_throw_if_error(qdb_ts_insert_columns(*_handle, _alias.c_str(), c_columns.data(), c_columns.size()));
     }
 
     std::vector<column_info> list_columns()
@@ -108,7 +108,7 @@ public:
         qdb_ts_column_info_t * columns = nullptr;
         qdb_size_t count               = 0;
 
-        QDB_THROW_IF_ERROR(qdb_ts_list_columns(*_handle, _alias.c_str(), &columns, &count));
+        qdb::qdb_throw_if_error(qdb_ts_list_columns(*_handle, _alias.c_str(), &columns, &count));
 
         auto c_columns = convert_columns(columns, count);
 
@@ -124,7 +124,7 @@ public:
 
         qdb_uint_t erased_count = 0;
 
-        QDB_THROW_IF_ERROR(qdb_ts_erase_ranges(*_handle, _alias.c_str(), column.c_str(), c_ranges.data(), c_ranges.size(), &erased_count));
+        qdb::qdb_throw_if_error(qdb_ts_erase_ranges(*_handle, _alias.c_str(), column.c_str(), c_ranges.data(), c_ranges.size(), &erased_count));
 
         return erased_count;
     }
@@ -133,25 +133,25 @@ public:
     void blob_insert(const std::string & column, const pybind11::array & timestamps, const pybind11::array & values)
     {
         const auto points = convert_values<qdb_ts_blob_point, const char *>{}(timestamps, values);
-        QDB_THROW_IF_ERROR(qdb_ts_blob_insert(*_handle, _alias.c_str(), column.c_str(), points.data(), points.size()));
+        qdb::qdb_throw_if_error(qdb_ts_blob_insert(*_handle, _alias.c_str(), column.c_str(), points.data(), points.size()));
     }
 
     void double_insert(const std::string & column, const pybind11::array & timestamps, const pybind11::array_t<double> & values)
     {
         const auto points = convert_values<qdb_ts_double_point, double>{}(timestamps, values);
-        QDB_THROW_IF_ERROR(qdb_ts_double_insert(*_handle, _alias.c_str(), column.c_str(), points.data(), points.size()));
+        qdb::qdb_throw_if_error(qdb_ts_double_insert(*_handle, _alias.c_str(), column.c_str(), points.data(), points.size()));
     }
 
     void int64_insert(const std::string & column, const pybind11::array & timestamps, const pybind11::array_t<std::int64_t> & values)
     {
         const auto points = convert_values<qdb_ts_int64_point, std::int64_t>{}(timestamps, values);
-        QDB_THROW_IF_ERROR(qdb_ts_int64_insert(*_handle, _alias.c_str(), column.c_str(), points.data(), points.size()));
+        qdb::qdb_throw_if_error(qdb_ts_int64_insert(*_handle, _alias.c_str(), column.c_str(), points.data(), points.size()));
     }
 
     void timestamp_insert(const std::string & column, const pybind11::array & timestamps, const pybind11::array_t<std::int64_t> & values)
     {
         const auto points = convert_values<qdb_ts_timestamp_point, std::int64_t>{}(timestamps, values);
-        QDB_THROW_IF_ERROR(qdb_ts_timestamp_insert(*_handle, _alias.c_str(), column.c_str(), points.data(), points.size()));
+        qdb::qdb_throw_if_error(qdb_ts_timestamp_insert(*_handle, _alias.c_str(), column.c_str(), points.data(), points.size()));
     }
 
 public:
@@ -162,7 +162,7 @@ public:
 
         const auto c_ranges = convert_ranges(ranges);
 
-        QDB_THROW_IF_ERROR(
+        qdb::qdb_throw_if_error(
             qdb_ts_blob_get_ranges(*_handle, _alias.c_str(), column.c_str(), c_ranges.data(), c_ranges.size(), &points, &count));
 
         const auto res = vectorize_result<qdb_ts_blob_point, const char *>{}(points, count);
@@ -179,7 +179,7 @@ public:
 
         const auto c_ranges = convert_ranges(ranges);
 
-        QDB_THROW_IF_ERROR(
+        qdb::qdb_throw_if_error(
             qdb_ts_double_get_ranges(*_handle, _alias.c_str(), column.c_str(), c_ranges.data(), c_ranges.size(), &points, &count));
 
         const auto res = vectorize_result<qdb_ts_double_point, double>{}(points, count);
@@ -196,7 +196,7 @@ public:
 
         const auto c_ranges = convert_ranges(ranges);
 
-        QDB_THROW_IF_ERROR(
+        qdb::qdb_throw_if_error(
             qdb_ts_int64_get_ranges(*_handle, _alias.c_str(), column.c_str(), c_ranges.data(), c_ranges.size(), &points, &count));
 
         const auto res = vectorize_result<qdb_ts_int64_point, std::int64_t>{}(points, count);
@@ -213,7 +213,7 @@ public:
 
         const auto c_ranges = convert_ranges(ranges);
 
-        QDB_THROW_IF_ERROR(
+        qdb::qdb_throw_if_error(
             qdb_ts_timestamp_get_ranges(*_handle, _alias.c_str(), column.c_str(), c_ranges.data(), c_ranges.size(), &points, &count));
 
         const auto res = vectorize_result<qdb_ts_timestamp_point, std::int64_t>{}(points, count);

--- a/quasardb_module/ts_batch.hpp
+++ b/quasardb_module/ts_batch.hpp
@@ -72,7 +72,7 @@ public:
         std::transform(
             ci.cbegin(), ci.cend(), converted.begin(), [](const batch_column_info & ci) -> qdb_ts_batch_column_info_t { return ci; });
 
-        QDB_THROW_IF_ERROR(qdb_ts_batch_table_init(*_handle, converted.data(), converted.size(), &_batch_table));
+        qdb::qdb_throw_if_error(qdb_ts_batch_table_init(*_handle, converted.data(), converted.size(), &_batch_table));
     }
 
     // prevent copy because of the table object, use a unique_ptr of the batch in cluster
@@ -92,38 +92,38 @@ public:
     void start_row(std::int64_t ts)
     {
         const qdb_timespec_t converted = convert_timestamp(ts);
-        QDB_THROW_IF_ERROR(qdb_ts_batch_start_row(_batch_table, &converted));
+        qdb::qdb_throw_if_error(qdb_ts_batch_start_row(_batch_table, &converted));
     }
 
     void set_blob(std::size_t index, const std::string & blob)
     {
-        QDB_THROW_IF_ERROR(qdb_ts_batch_row_set_blob(_batch_table, index, blob.data(), blob.size()));
+        qdb::qdb_throw_if_error(qdb_ts_batch_row_set_blob(_batch_table, index, blob.data(), blob.size()));
     }
 
     void set_double(std::size_t index, double v)
     {
-        QDB_THROW_IF_ERROR(qdb_ts_batch_row_set_double(_batch_table, index, v));
+        qdb::qdb_throw_if_error(qdb_ts_batch_row_set_double(_batch_table, index, v));
     }
 
     void set_int64(std::size_t index, std::int64_t v)
     {
-        QDB_THROW_IF_ERROR(qdb_ts_batch_row_set_int64(_batch_table, index, v));
+        qdb::qdb_throw_if_error(qdb_ts_batch_row_set_int64(_batch_table, index, v));
     }
 
     void set_timestamp(std::size_t index, std::int64_t v)
     {
         const qdb_timespec_t converted = convert_timestamp(v);
-        QDB_THROW_IF_ERROR(qdb_ts_batch_row_set_timestamp(_batch_table, index, &converted));
+        qdb::qdb_throw_if_error(qdb_ts_batch_row_set_timestamp(_batch_table, index, &converted));
     }
 
     void push()
     {
-        QDB_THROW_IF_ERROR(qdb_ts_batch_push(_batch_table));
+        qdb::qdb_throw_if_error(qdb_ts_batch_push(_batch_table));
     }
 
     void push_async()
     {
-        QDB_THROW_IF_ERROR(qdb_ts_batch_push_async(_batch_table));
+        qdb::qdb_throw_if_error(qdb_ts_batch_push_async(_batch_table));
     }
 
 private:


### PR DESCRIPTION
Also fixed potential memory leak when queries result in both a non-null result and an error: an error is still thrown and the result is still discarded, only properly this time.