### PR TITLE
QDB-2057 - Move the C API version check from module import to Cluster object instantiation

### DIFF
--- a/quasardb_module/cluster.hpp
+++ b/quasardb_module/cluster.hpp
@@ -39,6 +39,7 @@
 #include "ts.hpp"
 #include "ts_batch.hpp"
 #include "utils.hpp"
+#include "version.hpp"
 #include <qdb/node.h>
 #include <qdb/prefix.h>
 #include <qdb/suffix.h>
@@ -60,6 +61,9 @@ public:
         , _handle{make_handle_ptr()}
         , _json_loads{pybind11::module::import("json").attr("loads")}
     {
+        // Check that the C API version installed on the target system matches
+        // the one used during the build
+        check_qdb_c_api_version(qdb_version());
         // must specify everything or nothing
         if (user_name.empty() != user_private_key.empty()) throw qdb::exception{qdb_e_invalid_argument};
         if (user_name.empty() != cluster_public_key.empty()) throw qdb::exception{qdb_e_invalid_argument};

--- a/quasardb_module/qdb_client.cpp
+++ b/quasardb_module/qdb_client.cpp
@@ -29,7 +29,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "cluster.hpp"
-#include "version.hpp"
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
@@ -41,7 +40,6 @@ PYBIND11_MODULE(quasardb, m)
     m.doc() = "QuasarDB Official Python API";
 
     m.def("version", &qdb_version, "Return version number");
-    qdb::check_qdb_c_api_version(qdb_version());
     m.def("build", &qdb_build, "Return build number");
 
     m.attr("never_expires") = std::chrono::system_clock::time_point{};

--- a/testcases/test_cluster.py
+++ b/testcases/test_cluster.py
@@ -1,0 +1,21 @@
+
+import re
+import unittest
+from settings import quasardb
+
+__INVALID_URI__ = "_qdb_://invaliduri"
+
+class QuasardbCluster(unittest.TestCase):
+    def test_capi_version_check():
+        # This will throw everytime
+        # The version check is the most critical step so it is done first.
+        # We thus just have to check that the error we get is related to
+        # this heck to figure how it went.
+        versionCheckPassed = False
+        msg = ""
+        try:
+            c = quasardb.Cluster(__INVALID_URI__)
+        except quasardb.Error as e:
+            msg = e.what()
+            versionCheckPassed = not "QuasarDB C API version" in msg
+        self.assertTrue(versionCheckPassed, message=msg)

--- a/testcases/test_cluster.py
+++ b/testcases/test_cluster.py
@@ -3,13 +3,11 @@ import re
 import unittest
 from settings import quasardb
 
-def make_invalid_cluster():
-    return quasardb.Cluster("_qdb_://invaliduri")
-
 class QuasardbCluster(unittest.TestCase):
     def test_capi_version_check():
         # This will throw everytime
         # The version check is the most critical step so it is done first.
         # We thus just have to check that the error we get is related to
         # this check to figure how it went.
-        self.assertRaisesRegexp(quasardb.Error, "^((?!C API version).)*$", make_invalid_cluster)
+        self.assertRaisesRegexp(quasardb.Error, "^((?!C API version).)*$",
+            quasardb.Cluster, "_qdb_://invaliduri")

--- a/testcases/test_cluster.py
+++ b/testcases/test_cluster.py
@@ -3,19 +3,13 @@ import re
 import unittest
 from settings import quasardb
 
-__INVALID_URI__ = "_qdb_://invaliduri"
+def make_invalid_cluster():
+    return quasardb.Cluster("_qdb_://invaliduri")
 
 class QuasardbCluster(unittest.TestCase):
     def test_capi_version_check():
         # This will throw everytime
         # The version check is the most critical step so it is done first.
         # We thus just have to check that the error we get is related to
-        # this heck to figure how it went.
-        versionCheckPassed = False
-        msg = ""
-        try:
-            c = quasardb.Cluster(__INVALID_URI__)
-        except quasardb.Error as e:
-            msg = e.what()
-            versionCheckPassed = not "QuasarDB C API version" in msg
-        self.assertTrue(versionCheckPassed, message=msg)
+        # this check to figure how it went.
+        self.assertRaisesRegexp(quasardb.Error, "^((?!C API version).)*$", make_invalid_cluster)


### PR DESCRIPTION
This is to avoid the very confusing behavior when an import error occurs within a Python script (the name for the import object holds the `ImportError` exception instance instead of the module).

Since the user has to create a `Cluster` to do actual things, it is a good place to put the check instead.