### PR TITLE
[CMake] Stub for linking qdb_api_static.

### DIFF
--- a/quasardb/CMakeLists.txt
+++ b/quasardb/CMakeLists.txt
@@ -3,6 +3,8 @@ project(quasardb)
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 
+option(QDB_LINK_STATIC_LIB "Link qdb_api_static instead of dynamic qdb_api." OFF)
+
 set(PACKAGE_NAME quasardb)
 
 # add_compile_options(
@@ -89,41 +91,42 @@ include_directories(${CMAKE_SOURCE_DIR})
 get_filename_component(QDB_API_LIB_REAL ${QDB_API_LIB} REALPATH)
 get_filename_component(QDB_API_LIB_REAL_NAME ${QDB_API_LIB_REAL} NAME)
 
-set(FILES_TO_COPY)
+if(NOT QDB_LINK_STATIC_LIB)
+  set(FILES_TO_COPY)
 
-if(WIN32)
-  list(APPEND FILES_TO_COPY "${QDB_API_DIR}/bin/qdb_api.dll")
-elseif(APPLE)
-  file(
-    GLOB SO_LIBS
-    LIST_DIRECTORIES false
-    "${QDB_API_DIR}/lib/libc[x+][x+]*.dylib")
+  if(WIN32)
+    list(APPEND FILES_TO_COPY "${QDB_API_DIR}/bin/qdb_api.dll")
+  elseif(APPLE)
+    file(
+      GLOB SO_LIBS
+      LIST_DIRECTORIES false
+      "${QDB_API_DIR}/lib/libc[x+][x+]*.dylib")
 
-  list(APPEND FILES_TO_COPY "${QDB_API_LIB_REAL}" ${SO_LIBS})
-elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
-  file(
-    GLOB SO_LIBS
-    LIST_DIRECTORIES false
-    "${QDB_API_DIR}/lib/libc[x+][x+]*.so*")
+    list(APPEND FILES_TO_COPY "${QDB_API_LIB_REAL}" ${SO_LIBS})
+  elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
+    file(
+      GLOB SO_LIBS
+      LIST_DIRECTORIES false
+      "${QDB_API_DIR}/lib/libc[x+][x+]*.so*")
 
-  list(APPEND FILES_TO_COPY "${QDB_API_LIB_REAL}" ${SO_LIBS})
-else()
-  list(APPEND FILES_TO_COPY "${QDB_API_LIB_REAL}")
-  # Is there a case where the C API library is not called libqdb_api.so?
-  # file(RENAME "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${QDB_API_LIB_REAL_NAME}"
-  # "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libqdb_api.so")
+    list(APPEND FILES_TO_COPY "${QDB_API_LIB_REAL}" ${SO_LIBS})
+  else()
+    list(APPEND FILES_TO_COPY "${QDB_API_LIB_REAL}")
+    # Is there a case where the C API library is not called libqdb_api.so?
+    # file(RENAME "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${QDB_API_LIB_REAL_NAME}"
+    # "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libqdb_api.so")
+  endif()
+
+  message(STATUS "Files to copy: ${FILES_TO_COPY}")
+  file(COPY ${FILES_TO_COPY} DESTINATION "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+
+  # for Apple we need to change the id otherwise we won't be able to load the
+  # extension
+  if(APPLE)
+    execute_process(COMMAND install_name_tool -id "@loader_path/libqdb_api.dylib"
+                            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libqdb_api.dylib)
+  endif()
 endif()
-
-message(STATUS "Files to copy: ${FILES_TO_COPY}")
-file(COPY ${FILES_TO_COPY} DESTINATION "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
-
-# for Apple we need to change the id otherwise we won't be able to load the
-# extension
-if(APPLE)
-  execute_process(COMMAND install_name_tool -id "@loader_path/libqdb_api.dylib"
-                          ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libqdb_api.dylib)
-endif()
-
 
 # step 3: build
 pybind11_add_module(
@@ -155,10 +158,88 @@ pybind11_add_module(
   utils/blob_deque.hpp
   utils/ostream.hpp
   utils/permutation.hpp
-  utils/stable_sort.hpp)
+  utils/stable_sort.hpp
+)
 
 target_compile_definitions(quasardb PUBLIC QDB_PY_VERSION="${QDB_PY_VERSION}")
-target_link_libraries(quasardb PUBLIC ${QDB_API_LIB})
+if(QDB_LINK_STATIC_LIB)
+  add_definitions(-DQDB_API_STATIC_LINK=1)
+
+  set(LIB_DIR "${QDB_API_DIR}/lib_static")
+  if(WIN32)
+    set(LIB_PREFIX "")
+    set(LIB_SUFFIX "$<$<CONFIG:Debug>:d>.lib")
+  else()
+    set(LIB_PREFIX "lib")
+    set(LIB_SUFFIX "$<$<CONFIG:Debug>:d>.a")
+  endif()
+
+  target_link_libraries(quasardb
+    PUBLIC
+      "${LIB_DIR}/${LIB_PREFIX}qdb_api_static${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_query_client${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_client${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_aggregation${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_chord${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_network${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_protocol${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_perf${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_persistence${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_application${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}rocksdb${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}zlibstatic${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_query${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}geohash${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_timeseries${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_query_dsl${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}arrow${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_metadata${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_config${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}boost_program_options${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_serialization${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_compression${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_serialization${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_compression${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_auth${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_crypto${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_json${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_id${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}skein${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_network_resolver${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}libsodium${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_io${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_log${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}lz4${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_sys${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_time${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}brigand${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_util${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}boost_filesystem${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}fmt${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}robin_hood${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}asio${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}xxhash${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_memory${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}tbbmalloc${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}tbb${LIB_SUFFIX}"
+      "${LIB_DIR}/${LIB_PREFIX}qdb_version${LIB_SUFFIX}"
+  )
+
+  if(WIN32)
+    target_link_libraries(quasardb
+      PUBLIC
+        "${LIB_DIR}/${LIB_PREFIX}zstd_static${LIB_SUFFIX}"
+    )
+  else()
+    target_link_libraries(quasardb
+      PUBLIC
+        "${LIB_DIR}/${LIB_PREFIX}boost_system${LIB_SUFFIX}"
+        "${LIB_DIR}/${LIB_PREFIX}zstd${LIB_SUFFIX}"
+    )
+  endif()
+else()
+  target_link_libraries(quasardb PUBLIC ${QDB_API_LIB})
+endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX)
   target_link_options(

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,11 @@ class CMakeBuild(build_ext):
         # We provide CMAKE_LIBRARY_OUTPUT_DIRECTORY to cmake, where it will copy libqdb_api.so (or
         # whatever the OS uses). It is important that this path matches `package_modules`, so that
         # setuptools knows it needs to package this.
-        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-                      '-DPYTHON_EXECUTABLE=' + sys.executable,
-                      '-DQDB_PY_VERSION=' + qdb_version]
+        cmake_args = [
+            '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+            '-DPYTHON_EXECUTABLE=' + sys.executable,
+            '-DQDB_PY_VERSION=' + qdb_version,
+        ]
 
         # NOTE: Run `python setup.py build_ext --debug bdist_wheel ...` for Debug build.
         cfg = 'Debug' if self.debug else 'Release'
@@ -81,6 +83,12 @@ class CMakeBuild(build_ext):
         #    build_args += ['--', '-j2']
 
         env = os.environ.copy()
+
+        additional_cmake_params = env.get('ADDITIONAL_CMAKE_PARAMETERS')
+        if additional_cmake_params:
+            additional_cmake_params = additional_cmake_params.split(':')
+            cmake_args += additional_cmake_params
+
         env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
                                                               self.distribution.get_version())
         if not os.path.exists(self.build_temp):


### PR DESCRIPTION
To invoke, set env. var. `ADDITIONAL_CMAKE_PARAMETERS=-DQDB_LINK_STATIC_LIB=ON`.

To be used manually, not on TeamCity for the moment.

