### PR TITLE
QDB-12511- Investigate cluster connection closing / not closing

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -112,3 +112,9 @@ def test_connect_with_open_to_secure_cluster(qdbd_settings):
             qdbd_settings.get('uri').get('insecure'))
 
         assert len(topology) > 0
+        
+def test_connect_throws_exception_when_accessing_outside_with_open(qdbd_settings):
+    with pytest.raises(Exception):
+        with quasardb.Cluster('qdb://127.0.0.1:2836') as conn:
+            pass
+        conn.node_topology(qdbd_settings.get('uri').get('insecure'))


### PR DESCRIPTION
Tests if connection is closed outside with. For now it fails as connection is not closed when outside with statement. 

Issue is that if connection is closed manually than this test case should pass but instead it throws `Fatal Python error: Segmentation fault at line 120`.

I tried it in diffrent python enviroment with quasardb 3.14.1.dev4 installed and it worked as it should.