### PR TITLE
QDB-14207 - Fix Python error in ODBC driver tests

### DIFF
--- a/quasardb/__init__.py
+++ b/quasardb/__init__.py
@@ -119,9 +119,5 @@ if not 'quasardb' in locals():
     raise ImportError()
 
 
-import sys
-sys.stdout.reconfigure(encoding='utf-8')
-sys.stderr.reconfigure(encoding='utf-8')
-
 from .extensions import extend_module
 extend_module(quasardb)

--- a/quasardb/__init__.py
+++ b/quasardb/__init__.py
@@ -119,5 +119,9 @@ if not 'quasardb' in locals():
     raise ImportError()
 
 
+import sys
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
 from .extensions import extend_module
 extend_module(quasardb)

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -119,8 +119,6 @@ def test_dataframe(qdbpd_write_fn, df_with_table, qdbd_connection):
 
     df2 = qdbpd.read_dataframe(table)
 
-    print("df2: {}".format(df2))
-
     _assert_df_equal(df1, df2)
 
 @pytest.mark.parametrize('sparsify', conftest.no_sparsify)


### PR DESCRIPTION
the ODBC driver tests [fail on windows teamcity agents](http://teamcity-server:8111/buildConfiguration/Tools_OdbcDriver_Win32/411380?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildDeploymentsSection=false&expandBuildProblemsSection=true&showLog=411320_8222_1333.8222&logFilter=debug&logView=flowAware) because of a text encoding issue.
the same build [passes on linux](http://teamcity-server:8111/buildConfiguration/Tools_OdbcDriver_Linux/411393?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildDeploymentsSection=false), suggesting that utf-8 is preferred for tests to work normally.
I added a step in the api initialization to enforce utf-8 usage.