### PR TITLE
QDB-14314 - Add retry option

### DIFF
--- a/quasardb/CMakeLists.txt
+++ b/quasardb/CMakeLists.txt
@@ -386,7 +386,9 @@ if(QDB_TESTS_ENABLED)
 
     ../tests/conftest.cpp
     ../tests/conftest.hpp
-    ../tests/test_convert.cpp)
+    ../tests/test_convert.cpp
+    ../tests/test_writer_retry_options.cpp
+  )
 endif()
 
 # step 3: build

--- a/quasardb/detail/retry.hpp
+++ b/quasardb/detail/retry.hpp
@@ -90,6 +90,9 @@ struct retry_options
      */
     retry_options next() const
     {
+
+        assert(has_next() == true);
+
         return retry_options{retries_left_ - 1, delay_ * exponent_, exponent_, jitter_};
     }
 

--- a/quasardb/detail/retry.hpp
+++ b/quasardb/detail/retry.hpp
@@ -32,7 +32,6 @@
 
 #include <pybind11/pybind11.h>
 #include <chrono>
-#include <random>
 
 namespace qdb::detail
 {

--- a/quasardb/detail/retry.hpp
+++ b/quasardb/detail/retry.hpp
@@ -104,4 +104,17 @@ struct retry_options
     }
 };
 
+constexpr bool is_retryable(qdb_error_t e)
+{
+    switch (e)
+    {
+    case qdb_e_async_pipe_full:
+    case qdb_e_try_again:
+        return true;
+        break;
+    default:
+        return false;
+    };
+}
+
 }; // namespace qdb::detail

--- a/quasardb/detail/retry.hpp
+++ b/quasardb/detail/retry.hpp
@@ -1,0 +1,107 @@
+/*
+ *
+ * Official Python API
+ *
+ * Copyright (c) 2009-2021, quasardb SAS. All rights reserved.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of quasardb nor the names of its contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY QUASARDB AND CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE REGENTS AND CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <chrono>
+#include <random>
+
+namespace qdb::detail
+{
+
+struct retry_options
+{
+    // how many retries are left. 0 means no retries
+    std::size_t retries_left_;
+
+    // delay for the next retry
+    std::chrono::milliseconds delay_;
+
+    // factor by which delay is increased every retry
+    std::size_t exponent_;
+
+    // random jitter added/removed to delay_. Jitter of 0.1 means that 10% is automatically
+    // added or removed from delay_
+    double jitter_;
+
+    retry_options(std::size_t retries   = 0,
+        std::chrono::milliseconds delay = std::chrono::milliseconds{3000},
+        std::size_t exponent            = 2,
+        double jitter                   = 0.1)
+        : retries_left_{retries}
+        , delay_{delay}
+        , exponent_{exponent}
+        , jitter_{jitter}
+    {}
+
+    static retry_options from_kwargs(py::kwargs args)
+    {
+        if (!args.contains("retries"))
+        {
+            return {};
+        }
+
+        if (!args.contains("retry_delay"))
+        {
+            return {args["retries"].cast<std::size_t>()};
+        }
+
+        // TODO(leon): support additional arguments such as exponent and jitter.
+        //             for now we just use default values.
+        return {
+            args["retries"].cast<std::size_t>(), args["retry_delay"].cast<std::chrono::milliseconds>()};
+    }
+
+    inline constexpr bool has_next() const
+    {
+        return retries_left_ > 0;
+    }
+
+    /**
+     * Returns new object, with `retries_left_` and `delay_` adjusted accordingly.
+     */
+    retry_options next() const
+    {
+        return retry_options{retries_left_ - 1, delay_ * exponent_, exponent_, jitter_};
+    }
+
+    /**
+     * Returns the next sleep duration, based on `delay_` and the provided jitter.
+     */
+
+    std::chrono::milliseconds sleep_duration() const
+    {
+        // TODO(leon): include jitter_
+        return delay_;
+    }
+};
+
+}; // namespace qdb::detail

--- a/quasardb/error.hpp
+++ b/quasardb/error.hpp
@@ -186,6 +186,33 @@ public:
     {}
 };
 
+class try_again_exception : public exception
+{
+public:
+    try_again_exception() noexcept
+        : exception(qdb_e_try_again,
+            std::string("The operation could not be completed at this time, please try again"))
+    {}
+
+    try_again_exception(std::string const & what) noexcept
+        : exception(qdb_e_try_again, what)
+    {}
+};
+
+class async_pipeline_full_exception : public exception
+{
+public:
+    async_pipeline_full_exception() noexcept
+        : exception(qdb_e_async_pipe_full,
+            std::string("The async pipelines are currently full, please try again later or slow down "
+                        "your ingestion speed."))
+    {}
+
+    async_pipeline_full_exception(std::string const & what) noexcept
+        : exception(qdb_e_async_pipe_full, what)
+    {}
+};
+
 class invalid_datetime_exception : public exception
 {
 public:
@@ -292,6 +319,12 @@ inline void qdb_throw_if_error(
         case qdb_e_invalid_argument:
             throw qdb::invalid_argument_exception{msg_data_};
 
+        case qdb_e_try_again:
+            throw qdb::try_again_exception{msg_data_};
+
+        case qdb_e_async_pipe_full:
+            throw qdb::async_pipeline_full_exception{msg_data_};
+
         default:
             throw qdb::exception{err_, msg_data_};
         };
@@ -329,6 +362,8 @@ static inline void register_errors(Module & m)
     py::register_exception<qdb::invalid_argument_exception>(m, "InvalidArgumentError", base_class);
     py::register_exception<qdb::invalid_query_exception>(m, "InvalidQueryError", base_class);
     py::register_exception<qdb::invalid_handle_exception>(m, "InvalidHandleError", base_class);
+    py::register_exception<qdb::try_again_exception>(m, "TryAgainError", base_class);
+    py::register_exception<qdb::async_pipeline_full_exception>(m, "AsyncPipelineFullError", base_class);
 }
 
 } // namespace qdb

--- a/quasardb/numpy/__init__.py
+++ b/quasardb/numpy/__init__.py
@@ -569,7 +569,8 @@ def write_arrays(
         deduplicate=False,
         deduplication_mode='drop',
         infer_types = True,
-        writer = None):
+        writer = None,
+        retries = 0):
     """
     Write multiple aligned numpy arrays to a table.
 
@@ -658,6 +659,14 @@ def write_arrays(
 
       Reuse of the Writer allows for some performance improvements.
 
+
+    retries: optional int
+      Number of times to retry in case of a push failure. This is useful in case of async
+      pipeline failures, or when doing transactional inserts that may occasionally cause
+      transaction conflicts.
+
+      Retries with exponential backoff, starts at 3 seconds, and doubles every retry attempt.
+
     """
 
     if table:
@@ -673,7 +682,8 @@ def write_arrays(
                             deduplicate=deduplicate,
                             deduplication_mode=deduplication_mode,
                             infer_types=infer_types,
-                            writer=writer)
+                            writer=writer,
+                            retries=retries)
 
 
     ret = []

--- a/quasardb/pandas/__init__.py
+++ b/quasardb/pandas/__init__.py
@@ -311,7 +311,8 @@ def write_dataframes(
         deduplicate=False,
         deduplication_mode='drop',
         infer_types=True,
-        writer=None):
+        writer=None,
+        retries=0):
     """
     Store a dataframe into a table with the pin column API.
 
@@ -378,6 +379,13 @@ def write_dataframes(
 
       Defaults to False.
 
+    retries: optional int
+      Number of times to retry in case of a push failure. This is useful in case of async
+      pipeline failures, or when doing transactional inserts that may occasionally cause
+      transaction conflicts.
+
+      Retries with exponential backoff, starts at 3 seconds, and doubles every retry attempt.
+
     """
 
     # If dfs is a dict, we convert it to a list of tuples.
@@ -430,7 +438,8 @@ def write_dataframes(
                               deduplicate=deduplicate,
                               deduplication_mode=deduplication_mode,
                               infer_types=infer_types,
-                              writer=writer)
+                              writer=writer,
+                              retries=retries)
 
 def write_dataframe(
         df,

--- a/quasardb/writer.cpp
+++ b/quasardb/writer.cpp
@@ -479,8 +479,9 @@ detail::deduplicate_options writer::_deduplicate_from_args(py::kwargs args)
     return staged_tables;
 }
 
-void writer::_do_push(
-    qdb_exp_batch_push_mode_t mode, std::vector<qdb_exp_batch_push_table_t> const & batch)
+void writer::_do_push(qdb_exp_batch_push_mode_t mode,
+    std::vector<qdb_exp_batch_push_table_t> const & batch,
+    detail::retry_options const & retry_options)
 {
     // Make sure to measure the time it takes to do the actual push
     qdb::metrics::scoped_capture capture{"qdb_batch_push"};
@@ -526,7 +527,7 @@ void writer::_push_impl(writer::staged_tables_t & staged_tables,
             batch_table.data.column_count, table_name);
     }
 
-    _do_push(mode, batch);
+    _do_push(mode, batch, retry_options);
 }
 
 void register_writer(py::module_ & m)

--- a/quasardb/writer.cpp
+++ b/quasardb/writer.cpp
@@ -466,11 +466,44 @@ void writer::_do_push(qdb_exp_batch_push_mode_t mode,
     std::vector<qdb_exp_batch_push_table_t> const & batch,
     detail::retry_options const & retry_options)
 {
-    // Make sure to measure the time it takes to do the actual push
-    qdb::metrics::scoped_capture capture{"qdb_batch_push"};
+    qdb_error_t err{qdb_e_ok};
 
-    qdb::qdb_throw_if_error(
-        *_handle, qdb_exp_batch_push(*_handle, mode, batch.data(), nullptr, batch.size()));
+    {
+        // Make sure to measure the time it takes to do the actual push.
+        // This is in its own scoped block so that we only actually measure
+        // the push time, not e.g. retry time.
+        qdb::metrics::scoped_capture capture{"qdb_batch_push"};
+
+        err = qdb_exp_batch_push(*_handle, mode, batch.data(), nullptr, batch.size());
+    }
+
+    if (detail::is_retryable(err) && retry_options.has_next())
+        [[unlikely]] // Unlikely, because err is most likely to be qdb_e_ok
+    {
+        // The error is retryable, and we have retries left
+        std::chrono::milliseconds sleep = retry_options.sleep_duration();
+
+        if (err == qdb_e_async_pipe_full) [[likely]]
+        {
+            _logger.warn("Async pipelines are currently full");
+        }
+        else
+        {
+            _logger.warn("A temporary error occurred");
+        }
+
+        _logger.warn("Sleeping for %d milliseconds", sleep.count());
+
+        std::this_thread::sleep_for(sleep);
+
+        // Now try again -- easier way to go about this is to enter recursion. Note how
+        // we permutate the retry_options, which automatically adjusts the amount of retries
+        // left and the next sleep duration.
+        _logger.warn("Retrying push operation, retries left: %d", retry_options.retries_left_);
+        return _do_push(mode, batch, retry_options.next());
+    }
+
+    qdb::qdb_throw_if_error(*_handle, err);
 }
 
 void writer::_push_impl(writer::staged_tables_t & staged_tables,
@@ -490,7 +523,6 @@ void writer::_push_impl(writer::staged_tables_t & staged_tables,
     batch.assign(staged_tables.size(), qdb_exp_batch_push_table_t());
 
     int cur = 0;
-    _logger.debug("writer::_push_impl");
 
     for (auto pos = staged_tables.begin(); pos != staged_tables.end(); ++pos)
     {

--- a/quasardb/writer.cpp
+++ b/quasardb/writer.cpp
@@ -244,23 +244,6 @@ void staged_table::prepare_batch(qdb_exp_batch_push_mode_t mode,
         deduplicate_options.columns_);
 }
 
-/* static */ detail::retry_options detail::retry_options::from_kwargs(py::kwargs args)
-{
-    if (!args.contains("retries"))
-    {
-        return {};
-    }
-
-    if (!args.contains("retry_delay"))
-    {
-        return {args["retries"].cast<std::size_t>()};
-    }
-
-    // TODO(leon): support additional arguments such as exponent and jitter.
-    //             for now we just use default values.
-    return {args["retries"].cast<std::size_t>(), args["retry_delay"].cast<std::chrono::milliseconds>()};
-}
-
 }; // namespace qdb::detail
 
 namespace qdb

--- a/quasardb/writer.hpp
+++ b/quasardb/writer.hpp
@@ -371,6 +371,9 @@ private:
         detail::deduplicate_options deduplicate_options,
         qdb_ts_range_t * ranges = nullptr);
 
+    void _do_push(
+        qdb_exp_batch_push_mode_t mode, std::vector<qdb_exp_batch_push_table_t> const & batch);
+
     detail::deduplicate_options _deduplicate_from_args(py::kwargs args);
 
 private:

--- a/quasardb/writer.hpp
+++ b/quasardb/writer.hpp
@@ -111,6 +111,16 @@ struct retry_options
     {}
 
     static retry_options from_kwargs(py::kwargs args);
+
+    inline constexpr bool has_next() const
+    {
+        return retries_left_ > 0;
+    }
+
+    inline retry_options next() const
+    {
+        return retry_options{retries_left_ - 1, delay_ * exponent_, exponent_, jitter_};
+    }
 };
 
 using int64_column     = std::vector<qdb_int_t>;
@@ -401,8 +411,9 @@ private:
         detail::retry_options const & retry_options,
         qdb_ts_range_t * ranges = nullptr);
 
-    void _do_push(
-        qdb_exp_batch_push_mode_t mode, std::vector<qdb_exp_batch_push_table_t> const & batch);
+    void _do_push(qdb_exp_batch_push_mode_t mode,
+        std::vector<qdb_exp_batch_push_table_t> const & batch,
+        detail::retry_options const & retry_options);
 
     detail::deduplicate_options _deduplicate_from_args(py::kwargs args);
 

--- a/quasardb/writer.hpp
+++ b/quasardb/writer.hpp
@@ -37,6 +37,7 @@
 #include "object_tracker.hpp"
 #include "table.hpp"
 #include "utils.hpp"
+#include <chrono>
 #include <variant>
 #include <vector>
 
@@ -82,6 +83,34 @@ struct deduplicate_options
     deduplicate_options(deduplication_mode_t mode, detail::deduplicate columns)
         : columns_{columns}
         , mode_{mode} {};
+};
+
+struct retry_options
+{
+    // how many retries are left. 0 means no retries
+    std::size_t retries_left_;
+
+    // delay for the next retry
+    std::chrono::milliseconds delay_;
+
+    // factor by which delay is increased every retry
+    std::size_t exponent_;
+
+    // random jitter. 0.1 means the next delay will be within 10% range (higher or
+    // lower) of delay_
+    double jitter_;
+
+    retry_options(std::size_t retries   = 0,
+        std::chrono::milliseconds delay = std::chrono::milliseconds{3000},
+        std::size_t exponent            = 2,
+        double jitter                   = 0.1)
+        : retries_left_{retries}
+        , delay_{delay}
+        , exponent_{exponent}
+        , jitter_{jitter}
+    {}
+
+    static retry_options from_kwargs(py::kwargs args);
 };
 
 using int64_column     = std::vector<qdb_int_t>;
@@ -368,7 +397,8 @@ private:
 
     void _push_impl(staged_tables_t & staged_tables,
         qdb_exp_batch_push_mode_t mode,
-        detail::deduplicate_options deduplicate_options,
+        detail::deduplicate_options const & deduplicate_options,
+        detail::retry_options const & retry_options,
         qdb_ts_range_t * ranges = nullptr);
 
     void _do_push(

--- a/tests/test_writer_retry_options.cpp
+++ b/tests/test_writer_retry_options.cpp
@@ -17,12 +17,13 @@ QDB_REGISTER_MODULE(test_writer_retry_options, m)
 
     m_.def("test_permutate_once", []() -> void {
         qdb::detail::retry_options retry_options{1};
-        TEST_CHECK_EQUAL(retry_options.retries_left_, 1);
         TEST_CHECK_EQUAL(retry_options.has_next(), true);
+        TEST_CHECK_EQUAL(retry_options.sleep_duration().count(), 3000);
 
         auto next_ = retry_options.next();
         TEST_CHECK_EQUAL(next_.retries_left_, 0);
         TEST_CHECK_EQUAL(next_.has_next(), false);
+        TEST_CHECK_EQUAL(next_.sleep_duration().count(), 6000);
     });
 }
 

--- a/tests/test_writer_retry_options.cpp
+++ b/tests/test_writer_retry_options.cpp
@@ -1,0 +1,29 @@
+#include "conftest.hpp"
+#include <module.hpp>
+#include <writer.hpp>
+
+namespace qdb
+{
+
+QDB_REGISTER_MODULE(test_writer_retry_options, m)
+{
+    auto m_ = m.def_submodule("test_writer_retry_options");
+
+    m_.def("test_default_no_retry", []() -> void {
+        qdb::detail::retry_options retry_options{};
+        TEST_CHECK_EQUAL(retry_options.retries_left_, 0);
+        TEST_CHECK_EQUAL(retry_options.has_next(), false);
+    });
+
+    m_.def("test_permutate_once", []() -> void {
+        qdb::detail::retry_options retry_options{1};
+        TEST_CHECK_EQUAL(retry_options.retries_left_, 1);
+        TEST_CHECK_EQUAL(retry_options.has_next(), true);
+
+        auto next_ = retry_options.next();
+        TEST_CHECK_EQUAL(next_.retries_left_, 0);
+        TEST_CHECK_EQUAL(next_.has_next(), false);
+    });
+}
+
+}; // namespace qdb

--- a/tests/test_writer_retry_options.py
+++ b/tests/test_writer_retry_options.py
@@ -1,0 +1,17 @@
+###
+#
+# XXX: If this import fails, ensure that you built the quasardb python API with
+#      export QDB_TESTS_ENABLED=ON. E.g.
+#
+#      ```
+#      export QDB_TESTS_ENABLED=ON
+#      python3 setup.py test --addopts "-s tests/test_convert.py"
+#      ```
+
+from quasardb import test_writer_retry_options as m
+
+def test_default_no_retry():
+    m.test_default_no_retry()
+
+def test_permutate_once():
+    m.test_permutate_once()


### PR DESCRIPTION
This PR adds the ability to retry to the Python API, for now only in the batch writer part.

It also adds two specialized exception classes for qdb_e_try_again and qdb_e_async_pipe_full, so that the error messages generated are more user-friendly.