### PR TITLE
QDB-14944 - Reduce complexity of different user properties tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,6 +248,11 @@ def row_count(request):
     yield request.param
 
 
+# Makes it easier to "select" a row count.
+def override_row_count(x):
+    return pytest.mark.parametrize('row_count', [x], ids=['row_count={}'.format(x)])
+
+
 @pytest.fixture(params=[1, 2, 4, 8, 16],
                 ids=['df_count=1',
                      'df_count=2',

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,9 +1,13 @@
 # pylint: disable=C0103,C0111,C0302,W0212,W0702
 
 import pytest
-import quasardb
+import conftest
+import numpy as np
 
 import logging
+
+import quasardb
+import quasardb.pandas as qdbpd
 
 logger = logging.getLogger("test-user-properties")
 
@@ -99,8 +103,11 @@ def _has_user_property_in_log_file(log_path, key, value):
     return False
 
 
-@pytest.mark.skip(reason="there is a bug in qdbd logging, this test hangs the build supsicios ticket: QDB-14910")
-def test_properties_in_log(qdbpd_write_fn, qdbpd_query_fn, qdbd_connection, df_with_table, table_name, column_name, random_identifier, random_string):
+# We really only need a single column type
+@conftest.override_sparsify('none')
+@conftest.override_cdtypes(np.dtype('unicode'))
+@conftest.override_row_count(224)
+def test_properties_in_log(qdbpd_write_fn, qdbd_connection, df_with_table, table_name, column_name, random_identifier, random_string):
     """
     This test is a bit more involved, it will try to ensure that the user properties metadata is actually
     logged in the qdbd logs.
@@ -120,8 +127,8 @@ def test_properties_in_log(qdbpd_write_fn, qdbpd_query_fn, qdbd_connection, df_w
 
     # a faulty query will emit a log entry that will contain the user properties
     try:
-        qdbpd_query_fn(qdbd_connection, "PUT BLOB a 'a'");
-        qdbpd_query_fn(qdbd_connection, "PUT BLOB a 'a'");
+        qdbpd.query(qdbd_connection, "PUT BLOB a 'a'");
+        qdbpd.query(qdbd_connection, "PUT BLOB a 'a'");
     except:
         pass
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -122,6 +122,8 @@ def test_properties_in_log(qdbpd_write_fn, qdbd_connection, df_with_table, table
 
     qdbd_connection.options().enable_user_properties()
 
+    # XXX(leon): do we even need to write this at all? It doesn't appear that the test
+    # even relies on this data being present?
     (_, _, df, table) = df_with_table
     qdbpd_write_fn(df, qdbd_connection, table, fast=True)
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -103,7 +103,10 @@ def _has_user_property_in_log_file(log_path, key, value):
     return False
 
 
-# We really only need a single column type
+# Ensure only a single variation is executed:
+#  - no null values / sparse data in table
+#  - single data type
+#  - no different ariations of row types
 @conftest.override_sparsify('none')
 @conftest.override_cdtypes(np.dtype('unicode'))
 @conftest.override_row_count(224)


### PR DESCRIPTION
This ensures only a single variation of this test is executed, which should greatly reduce the execution time of the tests.