### PR TITLE
QDB-16279 - Avoid side-effects for numpy write_arrays data argument

### DIFF
--- a/quasardb/numpy/__init__.py
+++ b/quasardb/numpy/__init__.py
@@ -792,7 +792,7 @@ def write_arrays(
             #
             # This ensures that the user can call the same function multiple times without
             # side-effects.
-            data_  = data_.copy()
+            data_ = data_.copy()
             index_ = data_.pop("$timestamp")
             assert "$timestamp" not in data_
         elif index is not None:

--- a/quasardb/numpy/__init__.py
+++ b/quasardb/numpy/__init__.py
@@ -787,6 +787,12 @@ def write_arrays(
         assert len(dtype) is len(cinfos)
 
         if index is None and isinstance(data_, dict) and "$timestamp" in data_:
+            # Create shallow copy of `data_` so that we don't modify the reference, i.e.
+            # delete keys.
+            #
+            # This ensures that the user can call the same function multiple times without
+            # side-effects.
+            data_  = data_.copy()
             index_ = data_.pop("$timestamp")
             assert "$timestamp" not in data_
         elif index is not None:

--- a/scripts/teamcity/20.test.sh
+++ b/scripts/teamcity/20.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$(cd "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -144,15 +144,16 @@ def test_arrays_read_write_data_as_dict(array_with_index_and_table, qdbd_connect
 @conftest.override_cdtypes("native")
 def test_provide_index_as_dict(array_with_index_and_table, qdbd_connection):
     """
-    * qdbnp.write_arrays()
-    * => pinned writer
-    * => no conversion
+    For convenience, we allow the `$timestamp` index also to provided as a dict
+    key.
     """
     (ctype, dtype, data, index, table) = array_with_index_and_table
 
     col = table.column_id_by_index(0)
+    dict_ = {"$timestamp": index, col: data}
+
     qdbnp.write_arrays(
-        {"$timestamp": index, col: data},
+        dict_,
         qdbd_connection,
         table,
         dtype=dtype,

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -165,6 +165,33 @@ def test_provide_index_as_dict(array_with_index_and_table, qdbd_connection):
 
     assert_indexed_arrays_equal((index, data), res)
 
+@conftest.override_cdtypes("native")
+def test_provide_index_as_dict_has_no_side_effects_sc16279(array_with_index_and_table, qdbd_connection):
+    """
+    In earlier versions of the API, we `pop`'ed the $timestamp from the provided dict without making a
+    shallow copy of the dict. This would cause re-invocations of the same function (e.g. in case of an
+    error) to not work, as the original dict had been modified.
+
+    The test below has been confirmed to trigger the original bug described in QDB-16279, and was fixed
+    afterwards.
+    """
+    (ctype, dtype, data, index, table) = array_with_index_and_table
+
+    col = table.column_id_by_index(0)
+
+    dict_ = {"$timestamp": index, col: data}
+    qdbnp.write_arrays(
+        dict_,
+        qdbd_connection,
+        table,
+        dtype=dtype,
+        infer_types=False,
+        truncate=True,
+    )
+
+    assert '$timestamp' in dict_
+
+
 
 ######
 #

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -165,8 +165,11 @@ def test_provide_index_as_dict(array_with_index_and_table, qdbd_connection):
 
     assert_indexed_arrays_equal((index, data), res)
 
+
 @conftest.override_cdtypes("native")
-def test_provide_index_as_dict_has_no_side_effects_sc16279(array_with_index_and_table, qdbd_connection):
+def test_provide_index_as_dict_has_no_side_effects_sc16279(
+    array_with_index_and_table, qdbd_connection
+):
     """
     In earlier versions of the API, we `pop`'ed the $timestamp from the provided dict without making a
     shallow copy of the dict. This would cause re-invocations of the same function (e.g. in case of an
@@ -189,8 +192,7 @@ def test_provide_index_as_dict_has_no_side_effects_sc16279(array_with_index_and_
         truncate=True,
     )
 
-    assert '$timestamp' in dict_
-
+    assert "$timestamp" in dict_
 
 
 ######

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -141,6 +141,30 @@ def test_arrays_read_write_data_as_dict(array_with_index_and_table, qdbd_connect
     assert_indexed_arrays_equal((index, data), res)
 
 
+@conftest.override_cdtypes("native")
+def test_provide_index_as_dict(array_with_index_and_table, qdbd_connection):
+    """
+    * qdbnp.write_arrays()
+    * => pinned writer
+    * => no conversion
+    """
+    (ctype, dtype, data, index, table) = array_with_index_and_table
+
+    col = table.column_id_by_index(0)
+    qdbnp.write_arrays(
+        {"$timestamp": index, col: data},
+        qdbd_connection,
+        table,
+        dtype=dtype,
+        infer_types=False,
+        truncate=True,
+    )
+
+    res = qdbnp.read_array(table, col)
+
+    assert_indexed_arrays_equal((index, data), res)
+
+
 ######
 #
 # Arrays tests


### PR DESCRIPTION
As reported, if the user invokes the function multiple times with the exact same arguments, the function may throw an error as it modifies the `data` dict in-place. This is not great.

This PR makes a shallow copy of the dict before `pop`'ing the item, which avoids this situation.