### PR TITLE
QDB-16636 - Remove incorrect assertion that causes segfault

### DIFF
--- a/quasardb/reader.cpp
+++ b/quasardb/reader.cpp
@@ -102,7 +102,6 @@ reader_iterator & reader_iterator::operator++()
         // I like assertions
         assert(handle_ != nullptr);
         assert(reader_ != nullptr);
-        assert(table_count_ != 0);
         assert(ptr_ != nullptr);
     } // if (err == qdb_e_iterator_end)
 


### PR DESCRIPTION
There was an incorrect assertion that caused segfaults under some circumstances, specifically when an operation did succeed but no tables were returned.