### PR TITLE
Fix pytest breaking changes

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -52,9 +52,9 @@ def _test_array_recode(array_with_index_and_table):
 
 @conftest.override_sparsify("partial")
 def test_array_recode_sparsify_partial(array_with_index_and_table):
-    return _test_array_recode(array_with_index_and_table)
+    _test_array_recode(array_with_index_and_table)
 
 
 @conftest.override_sparsify("none")
 def test_array_recode_sparsify_none(array_with_index_and_table):
-    return _test_array_recode(array_with_index_and_table)
+    _test_array_recode(array_with_index_and_table)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -44,7 +44,7 @@ def _test_array_recode(array_with_index_and_table):
         # XXX(leon): we don't yet support native qdb -> np.ndarray with dtype `null-terminated binary` (S). I don't think we
         #            should ever do this, but we do need it for input. That's why we can't test this right now, because we
         #            can't do it full circle.
-        return True
+        return
 
     (idx2, xs2) = m.test_array_recode(ctype, dtype, (idx1, xs1))
     assert_indexed_arrays_equal((idx1, xs1), (idx2, xs2))


### PR DESCRIPTION
Since pytesty 8.4.0 tests will fail, instead of raising a warning, if they return any value other than None.

https://docs.pytest.org/en/stable/changelog.html#pytest-8-4-0-2025-06-02

Issue was identified in `tests/test_convert.py` tests.
To fix:
* don't return True for `dtype.char == "S"` edge case
* don't return _test_array_recode - assertion happens inside this function already, no need to return anything